### PR TITLE
Add docker-compose to deploy the Factorio server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  factorio:
+    image: 'games_on_k8s/factorio:latest'
+    volumes: 
+       - 'factorio_saves:/opt/factorio/saves'
+       - 'factorio_mods:/opt/factorio/mods'
+    ports:
+      - '34197:34197'
+      - '27015:27015'
+volumes:
+  factorio_saves:
+    driver: local
+  factorio_mods:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '2'
 services:
   factorio:
-    image: 'games_on_k8s/factorio:latest'
+    image: 'quay.io/games_on_k8s/factorio:0.14.22'
     volumes: 
        - 'factorio_saves:/opt/factorio/saves'
        - 'factorio_mods:/opt/factorio/mods'
     ports:
-      - '34197:34197'
+      - '34197/udp:34197/udp'
       - '27015:27015'
 volumes:
   factorio_saves:


### PR DESCRIPTION
I've created a simple docker-compose which deploys the Factorio server with the default configuration.
I've tested playing Factorio and it works without problem.

If you want to try it:

* Clone the repo
* Execute:
`docker-compose up` 
In the root folder

I've created this docker-compose because I don't want to deploy a k8's cluster on my Raspberry Pi and this is the fastest way to deploy the server.
I will add tomorrow some changes in the README.md to improve the documentation.

Best regards
