### PR TITLE
Fix Image to use correct apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Greg Taylor <gtaylor@gc-taylor.com>
 
 RUN apt-get update && apt-get dist-upgrade -y && \
-    apt install -y python3 && apt-get clean
+    apt-get install -y python3 && apt-get clean
 
 WORKDIR /opt
 

--- a/make_release.sh
+++ b/make_release.sh
@@ -22,14 +22,14 @@ then
 fi
 
 docker build --build-arg factorio_version=${VERSION} \
-    -t quay.io/games_on_k8s/factorio:${VERSION} .
-docker run --rm -it quay.io/games_on_k8s/factorio:${VERSION}
+    -t quay.io/playnet/factorio:${VERSION} .
+docker run --rm -it quay.io/playnet/factorio:${VERSION}
 
 while true; do
     read -p "Publish the built image? (y/n) " yn
     case $yn in
         [Yy]* )
-            docker push quay.io/games_on_k8s/factorio:${VERSION}
+            docker push quay.io/playnet/factorio:${VERSION}
             break;;
         [Nn]* )
             exit;;

--- a/make_release.sh
+++ b/make_release.sh
@@ -22,14 +22,14 @@ then
 fi
 
 docker build --build-arg factorio_version=${VERSION} \
-    -t quay.io/playnet/factorio:${VERSION} .
-docker run --rm -it quay.io/playnet/factorio:${VERSION}
+    -t quay.io/games_on_k8s/factorio:${VERSION} .
+docker run --rm -it quay.io/games_on_k8s/factorio:${VERSION}
 
 while true; do
     read -p "Publish the built image? (y/n) " yn
     case $yn in
         [Yy]* )
-            docker push quay.io/playnet/factorio:${VERSION}
+            docker push quay.io/games_on_k8s/factorio:${VERSION}
             break;;
         [Nn]* )
             exit;;


### PR DESCRIPTION
It is not recommended to use apt in Docker Images as it is a user focused implementation of apt-get which might cause issues.