### PR TITLE
Can not set FACTORIO_RCON_PORT & FACTORIO_RCON_PASSWORD

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,8 @@ echo "###"
 echo "# Game server port is '${FACTORIO_PORT}'"
 echo "###"
 
-factorio_command="$factorio_command --rcon-port ${FACTORIO_RCON_PORT:-27015}"
+FACTORIO_PORT=${FACTORIO_RCON_PORT:-27015}
+factorio_command="$factorio_command --rcon-port ${FACTORIO_RCON_PORT}"
 echo "###"
 echo "# RCON port is '${FACTORIO_RCON_PORT}'"
 echo "###"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,22 +32,20 @@ echo "###"
 echo "# Game server port is '${FACTORIO_PORT}'"
 echo "###"
 
-if [ -z $FACTORIO_RCON_PORT ]
-then
-  factorio_command="$factorio_command --rcon-port ${FACTORIO_RCON_PORT:-27015}"
-  echo "###"
-  echo "# RCON port is '${FACTORIO_RCON_PORT}'"
-  echo "###"
-fi
+factorio_command="$factorio_command --rcon-port ${FACTORIO_RCON_PORT:-27015}"
+echo "###"
+echo "# RCON port is '${FACTORIO_RCON_PORT}'"
+echo "###"
 
 if [ -z $FACTORIO_RCON_PASSWORD ]
 then
   FACTORIO_RCON_PASSWORD=$(cat /dev/urandom | tr -dc 'a-f0-9' | head -c16)
-  echo "###"
-  echo "# RCON password is '${FACTORIO_RCON_PASSWORD}'"
-  echo "###"
-  factorio_command="${factorio_command} --rcon-password ${FACTORIO_RCON_PASSWORD}"
 fi
+
+echo "###"
+echo "# RCON password is '${FACTORIO_RCON_PASSWORD}'"
+echo "###"
+factorio_command="${factorio_command} --rcon-password ${FACTORIO_RCON_PASSWORD}"
 
 # TODO Adding this because of bug, will need to be removed once bug in factorio is fixed
 cd /opt/factorio/saves

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ echo "###"
 echo "# Game server port is '${FACTORIO_PORT}'"
 echo "###"
 
-FACTORIO_PORT=${FACTORIO_RCON_PORT:-27015}
+FACTORIO_RCON_PORT=${FACTORIO_RCON_PORT:-27015}
 factorio_command="$factorio_command --rcon-port ${FACTORIO_RCON_PORT}"
 echo "###"
 echo "# RCON port is '${FACTORIO_RCON_PORT}'"


### PR DESCRIPTION
It seems that setting ``FACTORIO_RCON_PORT`` & ``FACTORIO_RCON_PASSWORD`` actually causes the RCON options to **not** be passed to the server at all. I think this is due to a logic error which this PR addresses.